### PR TITLE
Small change that avoids spelling mistakes by throwing an exception when they happen. 

### DIFF
--- a/base/src/main/scala/razie/Boolean.scala
+++ b/base/src/main/scala/razie/Boolean.scala
@@ -5,10 +5,14 @@
  */
 package razie
 
-/** i can never find the stupid parse methods */
+/** i can never find the stupid parse methods
+ * Adapted by Alexandre Martins
+ */
 object Boolean {
   def apply (s:String) : Boolean = s.toUpperCase match {
      case "TRUE" | "ON" | "YES" => true
-     case _ => false
+     case "FALSE" | "OFF" | "NO" => false
+     case _ => throw new IllegalArgumentException("argument isn't an acceptable boolean value...");
+ 
   }
 }


### PR DESCRIPTION
Now this object does not return "false" when typing errors like "yess" occur. It throws an exception instead.
